### PR TITLE
Support deployment to Google Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN pip install --no-cache-dir -r  requirements.txt
 # Change to follow GCP Cloud Run specification
 ENV PORT=
 
+# retrivied from https://discuss.streamlit.io/t/has-anyone-deployed-to-google-cloud-platform/931/21
+RUN find /usr/local/lib/python3.9/site-packages/streamlit -type f \( -iname \*.py -o -iname \*.js \) -print0 | xargs -0 sed -i 's/healthz/health-check/g'
 
 COPY main.py .
 COPY data.py .
 COPY Event.py . 
 COPY heatmap_utils.py .
 
-CMD streamlit run main.py --server.port=${PORT} --browser.serverAddress="0.0.0.0"
+CMD streamlit run main.py --server.port=${PORT} --browser.serverAddress="0.0.0.0" --server.enableCORS False --server.enableXsrfProtection False

--- a/README.md
+++ b/README.md
@@ -1,18 +1,48 @@
 # Heatmap (Comet Circle)
 
-This project was originally made for [HackUTD-2021F](https://devpost.com/software/comet-clique), but because the project was so *amazing*, Project nebula decided to pick it and maintiain it!
+A Streamlit app to see a heatmap of all sections of classes at UTD and filter by relevant majors or schools. This was primarily intended for event organizers to see the best time to schedule their events, but can used by just about anyone.
 
-Access on (outdated):
-https://share.streamlit.io/trystonminsquero/hackutd-2021f/main/main.py
+Access on http://heatmap.utdnebula.com/:
 
-To get current build, build the project locally
+## Background
 
-## Instalation process
+This project was originally made for [HackUTD-2021F](https://devpost.com/software/comet-clique), but because the project was so _amazing_, Project nebula decided to pick it and maintain it!
+
+### Local Installation process
 
 1. clone the repo locally
-3. Create an Anaconda environment for the project (Download [Anaconda](https://www.anaconda.com/products/individual) if not installed already)
-4. Open the environment with the terminal and go into the project directory (use cd for windows)
-5. run the command: pip install -r requirments.txt
-6. run the command: streamlit run main.py
+2. Create an Anaconda environment for the project (Download [Anaconda](https://www.anaconda.com/products/individual) if not installed already)
+3. Open the environment with the terminal and go into the project directory (use cd for windows)
+4. run the command: pip install -r requirements.txt
+5. run the command: streamlit run main.py
 
 it should be running in your browser now, create an issue if you're having trouble!
+
+### Deployment on Google Cloud Run
+
+This section is meant for maintainers only
+
+1. Make sure you have [google cloud CLI](https://cloud.google.com/sdk/docs/install) installed
+
+2. make sure you are signed in google cloud cli and also have a project for your account
+
+3. Go to the project directory in the console
+
+4. Run the command, replacing \<ProjectName> and \<AppName> accordingly (AppName could be anything, but Project Name must be the project already made in Google Cloud):
+
+```
+gcloud builds submit --tag gcr.io/<ProjectName>/<AppName>  --project=<ProjectName>
+```
+
+5. Then run the command with the same variables from step 4
+
+```
+gcloud run deploy --image gcr.io/<ProjectName>/<AppName> --platform managed  --project=<ProjectName> --allow-unauthenticated
+```
+
+6. you will be prompted multiple times during all of this
+    - if it asks to install API's, say yes
+    - when it prompts you for service name, return to skip
+    - when it prompts you to specify region, use 23 (us-central1)
+
+It should give you a url where your project is being hosted. contact @TrystonMinsquero if you're having any trouble!

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,7 @@
+runtime: custom
+env: flex
+
+instance_class: F2
+
+network:
+    session_affinity: true


### PR DESCRIPTION
Closes #4
Closes #9

# Deployment

I had created a Dockerfile in order to deploy the streamlit app to google cloud run. Testing it out on a personal google cloud account project, there was a problem with the websocket connection. Upon further reading of [this github issue](https://github.com/streamlit/streamlit/issues/484#issue-509976299) and [this streamlit forum](https://discuss.streamlit.io/t/has-anyone-deployed-to-google-cloud-platform/931), it is safe to say Google cloud run really shouldn't be used to deploy streamlit projects. However, that does not mean it is impossible.

## Workaround

In order to the healthz conflict, we encounter upon deployment, created an app.yaml file and edited the dockerfile to hack around the error. This is not pretty and really shouldn't be done, but this is the only way I found to get around this error. You can read in more detail about the solution from [this comment](https://discuss.streamlit.io/t/has-anyone-deployed-to-google-cloud-platform/931/24). Ideally, we would just not deploy comet circle with streamlit or not use google cloud run.

## Instructions

I have also provided instructions on how to deploy this project on any google cloud project in the README.md. Very simple and is just two commands.
